### PR TITLE
[BE] Account 도메인 및 기본 CRUD API 구현

### DIFF
--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/controller/AccountController.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/controller/AccountController.java
@@ -1,0 +1,70 @@
+package tworeal.Animalcenter.domain.account.controller;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import tworeal.Animalcenter.global.dto.SingleResDto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+@RequestMapping("/account")
+public class AccountController {
+
+    /**
+     * Mock Post
+     * @return 200
+     */
+    @PostMapping
+    public ResponseEntity<SingleResDto<String>> postAccount() {
+
+        return new ResponseEntity<>(new SingleResDto<>("Post Success"), HttpStatus.CREATED);
+    }
+
+
+    /**
+     * Mock Patch
+     * @return 200
+     */
+    @PatchMapping("/edit")
+    public ResponseEntity<SingleResDto<String>> patchAccount() {
+
+        return new ResponseEntity<>(new SingleResDto<>("Patch Success"), HttpStatus.OK);
+    }
+
+    /**
+     * Mock Delete (상태패턴 사용을 위해 실제로는 Patch로 할 것임
+     * @return 200 OK로 변경하기
+     */
+    @PatchMapping("/remove")
+    public ResponseEntity<SingleResDto<String>> deleteAccount() {
+        // 상태변환 필요
+        return new ResponseEntity<>(new SingleResDto<>("Delete Success"), HttpStatus.OK);
+    }
+
+    @GetMapping
+    public ResponseEntity<SingleResDto<String>> getAccount() {
+
+        return new ResponseEntity<>(new SingleResDto<>("Get Success"), HttpStatus.OK);
+    }
+
+    /**
+     *
+     * @return 객체 ResponseDto를 Pageable로 감싸서 반환
+     */
+    @GetMapping("/all")
+    public ResponseEntity<Page> getAccounts(Pageable pageable) {
+        List<String> mockList = new ArrayList<>();
+        int count = 0;
+        while(count++<10) mockList.add("Mock"+count);
+        Page<String> page = new PageImpl(mockList, pageable, mockList.size());
+//        Page<String> dtoPage = page.map(String::new);
+//        Page<ArticleResDto> dtoPage = page.map(ArticleResDto::new);
+        return new ResponseEntity<>(page, HttpStatus.OK);
+    }
+
+}

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/dto/AccountPatchReqDto.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/dto/AccountPatchReqDto.java
@@ -1,0 +1,31 @@
+package tworeal.Animalcenter.domain.account.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import tworeal.Animalcenter.domain.account.entity.Account;
+import tworeal.Animalcenter.domain.account.entity.UserStatus;
+import tworeal.Animalcenter.domain.account.value.Name;
+import tworeal.Animalcenter.domain.account.value.Password;
+import tworeal.Animalcenter.domain.account.value.Photo;
+
+@Getter @Setter
+public class AccountPatchReqDto {
+
+    private String password;
+    private String nickname;
+    private String profile;
+    private UserStatus accountStatus;
+
+    /**
+     * 밸류지정방식
+     */
+    public Account toEntity() {
+        Account account = new Account().builder()
+                .password(new Password(this.password))
+                .nickname(new Name(this.nickname))
+                .profile(new Photo(this.profile))
+                .accountStatus(this.accountStatus)
+                .build();
+        return account;
+    }
+}

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/dto/AccountPostReqDto.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/dto/AccountPostReqDto.java
@@ -1,0 +1,33 @@
+package tworeal.Animalcenter.domain.account.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import tworeal.Animalcenter.domain.account.entity.Account;
+import tworeal.Animalcenter.domain.account.entity.UserStatus;
+import tworeal.Animalcenter.domain.account.value.Email;
+import tworeal.Animalcenter.domain.account.value.Name;
+import tworeal.Animalcenter.domain.account.value.Password;
+import tworeal.Animalcenter.domain.account.value.Photo;
+
+@Getter @Setter
+public class AccountPostReqDto {
+
+    private String email;
+
+    private String password;
+
+    private String nickname;
+
+    private String profile;
+
+    public Account toEntity() {
+        Account account = new Account().builder()
+                .email(new Email(this.email))
+                .password(new Password(this.password))
+                .nickname(new Name(this.nickname))
+                .profile(new Photo(this.profile))
+                .accountStatus(UserStatus.ACCOUNT_ACTIVE)
+                .build();
+        return account;
+    }
+}

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/dto/AccountResDto.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/dto/AccountResDto.java
@@ -1,0 +1,30 @@
+package tworeal.Animalcenter.domain.account.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import tworeal.Animalcenter.domain.account.entity.Account;
+
+@Getter @Setter
+public class AccountResDto {
+
+    private Long accountId;
+
+    private String email;
+
+    private String nickname;
+
+    private String profile;
+
+    private String accountStatus;
+
+
+    public AccountResDto(Account account) {
+        this.accountId = account.getAccountId();
+        this.email = account.getEmail().getEmail();
+        this.nickname = account.getNickname().getName();
+        this.profile = account.getProfile().getPhoto();
+        this.accountStatus = account.getAccountStatus().getStatus();
+    }
+}
+
+

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/entity/Account.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/entity/Account.java
@@ -1,0 +1,58 @@
+package tworeal.Animalcenter.domain.account.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotNull;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Entity
+public class Account {
+
+    @Id
+    private long id;
+
+    @Email
+    private String email;
+
+    @NotNull
+    private Name nickname;
+
+    @NotNull
+    private String password;
+
+    @NotNull
+    private Phone phone;
+
+    private UserState state;
+
+    /**
+     * 불변 밸류의 명료화
+     */
+    class Name {
+        private String nickname;
+
+        public Name (String nickname) {
+            this.nickname = nickname;
+        }
+    }
+
+    /**
+     * 불변 밸류의 명료화
+     */
+    class Phone {
+        private String phone;
+
+        public Phone (String phone) {
+            this.phone = phone;
+        }
+    }
+
+
+}

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/entity/Account.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/entity/Account.java
@@ -1,58 +1,64 @@
 package tworeal.Animalcenter.domain.account.entity;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import tworeal.Animalcenter.domain.account.value.*;
+import tworeal.Animalcenter.global.exception.dto.BusinessLogicException;
+import tworeal.Animalcenter.global.exception.exceptionCode.ExceptionCode;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.validation.constraints.Email;
-import javax.validation.constraints.NotNull;
+import javax.persistence.*;
+import java.util.Optional;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
+@Builder
 @Entity
 public class Account {
 
     @Id
-    private long id;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long accountId;
 
-    @Email
-    private String email;
-
-    @NotNull
+    @Embedded
+    private Email email;
+    @Embedded
     private Name nickname;
-
-    @NotNull
-    private String password;
-
-    @NotNull
+    @Embedded
+    private Password password;
+    @Embedded
+    private Photo profile;
+    @Embedded
     private Phone phone;
 
-    private UserState state;
+    @Enumerated(value = EnumType.STRING)
+    @Column(length = 20, nullable = false)  // 컬럼설정 지정 안할시 오류 발생 => Unable to instantiate custom type: org.hibernate.type.EnumType 에러발생
+    private UserStatus accountStatus;
 
-    /**
-     * 불변 밸류의 명료화
-     */
-    class Name {
-        private String nickname;
-
-        public Name (String nickname) {
-            this.nickname = nickname;
-        }
+    public void defaultProfile() {
+        if(this.profile.getPhoto()==null)
+            this.profile = new Photo("https://scontent-gmp1-1.xx.fbcdn.net/v/t1.18169-9/527016_499021583525593_732357164_n.jpg?_nc_cat=107&ccb=1-7&_nc_sid=09cbfe&_nc_ohc=CdbnqyyFWXkAX_obHCp&_nc_ht=scontent-gmp1-1.xx&oh=00_AfDBQSsLnCXMKoAPnGFrOeSBgvMp__vgjXLEqmtS6etfcw&oe=63F1DB6A");
     }
 
-    /**
-     * 불변 밸류의 명료화
-     */
-    class Phone {
-        private String phone;
-
-        public Phone (String phone) {
-            this.phone = phone;
-        }
+    public Account verifyAccount(Optional<Account> optMember) {
+        return optMember.orElseThrow(()->new BusinessLogicException(ExceptionCode.ACCOUNT_NOT_FOUND));
     }
 
+    public void modifyPassword(Password password){ this.password = password; }
+    public void modifyNickname(Name nickname){
+        this.nickname = nickname;
+    }
+    public void modifyProfile(Photo profile){
+        this.profile = profile;
+    }
+    public void modifyAccountStatus(UserStatus status){
+        this.accountStatus = status;
+    }
+    public void withdrawAccount(){ this.accountStatus = UserStatus.ACCOUNT_QUIT; }
 
+    public void checkPassword(String password) {
+        if(!this.password.getPassword().equals(password)) throw new BusinessLogicException(ExceptionCode.NON_ACCESS_MODIFY);
+    }
 }

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/entity/UserState.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/entity/UserState.java
@@ -1,0 +1,28 @@
+package tworeal.Animalcenter.domain.account.entity;
+
+import lombok.Getter;
+
+public enum UserState {
+    /**
+     * 계정 상태값
+     */
+    ACCOUNT_ACTIVE("활동중"),
+    ACCOUNT_SLEEP("휴면 계정"),
+    ACCOUNT_QUIT("탈퇴 계정");
+
+    /**
+     * 외부로 내보낼 Data 추가하는 필드값
+     * 불변 밸류
+     */
+    @Getter
+    private String status;
+
+    /**
+     * 객체 생성을 위한 값을 받아 생성된 객체에 넣어주기 위함
+     * 파라미터 + 필드 추가를 할 수 있다
+      * @param status
+     */
+    UserState(String status) {
+        this.status = status;
+    }
+}

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/entity/UserStatus.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/entity/UserStatus.java
@@ -2,7 +2,7 @@ package tworeal.Animalcenter.domain.account.entity;
 
 import lombok.Getter;
 
-public enum UserState {
+public enum UserStatus {
     /**
      * 계정 상태값
      */
@@ -10,10 +10,7 @@ public enum UserState {
     ACCOUNT_SLEEP("휴면 계정"),
     ACCOUNT_QUIT("탈퇴 계정");
 
-    /**
-     * 외부로 내보낼 Data 추가하는 필드값
-     * 불변 밸류
-     */
+
     @Getter
     private String status;
 
@@ -22,7 +19,7 @@ public enum UserState {
      * 파라미터 + 필드 추가를 할 수 있다
       * @param status
      */
-    UserState(String status) {
+    UserStatus(String status) {
         this.status = status;
     }
 }

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/repository/AccountRepository.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/repository/AccountRepository.java
@@ -1,0 +1,7 @@
+package tworeal.Animalcenter.domain.account.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import tworeal.Animalcenter.domain.account.entity.Account;
+
+public interface AccountRepository extends JpaRepository<Account, Long> {
+}

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/service/AccountService.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/service/AccountService.java
@@ -1,0 +1,10 @@
+package tworeal.Animalcenter.domain.account.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+public class AccountService {
+
+}

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/service/AccountService.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/service/AccountService.java
@@ -1,10 +1,94 @@
 package tworeal.Animalcenter.domain.account.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import tworeal.Animalcenter.domain.account.entity.Account;
+import tworeal.Animalcenter.domain.account.repository.AccountRepository;
+import tworeal.Animalcenter.global.exception.dto.BusinessLogicException;
+import tworeal.Animalcenter.global.exception.exceptionCode.ExceptionCode;
 
+import java.util.Optional;
+
+@RequiredArgsConstructor
 @Service
 @Transactional(readOnly = true)
 public class AccountService {
+    private final AccountRepository accountRepository;
+
+
+    /**
+     * 예시 코드
+     * accountId는 DB 연동 후 조회가 가능합니다.
+     * @param account : 객체명
+     * @return : 객체명 (식별자 반환을 위함)
+     */
+    @Transactional
+    public Account createAccount(Account account) {
+        account.defaultProfile();
+        return accountRepository.save(account);
+    }
+
+
+    /**
+     * 들어오는 값에 따라, 다음의 Patch 요청을 개별적으로 관리 가능합니다. (null이 아닐경우 수정되는 방식 미적용)
+     * 1. 회원 정보 변경 가능
+     * 2. 회원 상태 변경 가능
+     * 비즈니스 로직은 Account Entity 내에서 처리
+     * @param accountId 추후 JWT에서 추출 예정
+     */
+    @Transactional
+    public void modifyMember(Account account, Long accountId) {
+        Account existAccount = new Account().verifyAccount(accountRepository.findById(accountId));
+        Optional.ofNullable(account.getPassword()).ifPresent(existAccount::modifyPassword);
+        Optional.ofNullable(account.getNickname()).ifPresent(existAccount::modifyNickname);
+        Optional.ofNullable(account.getProfile()).ifPresent(existAccount::modifyProfile);  // 현재 profile의 경우 단순 URI상태. 추후 파일로 변경 예정
+        Optional.ofNullable(account.getAccountStatus()).ifPresent(existAccount::modifyAccountStatus);
+
+        accountRepository.save(existAccount);
+    }
+
+
+    /**
+     * Account 완전 삭제시 사용
+     */
+    @Transactional
+    public void removeAccount (Long accountId) {
+        Account verifyAccount = new Account().verifyAccount(accountRepository.findById(accountId));
+        accountRepository.delete(verifyAccount);
+    }
+
+    /**
+     * Account Entity클래스 내 구현한 회원탈퇴 메소드(withdrawAccount 호출)
+     */
+    @Transactional
+    public void withdrawAccount (Long accountId) {
+        Account verifyAccount = new Account().verifyAccount(accountRepository.findById(accountId));
+        verifyAccount.withdrawAccount();
+        accountRepository.save(verifyAccount);
+    }
+
+
+    /**
+     * 현재는 Controller에서 String 반환중
+     * @param accountId  : 추후 시큐리티 구현 후 적용될 예정
+     * @return : 1명의 member 정보를 반환 => 맞춰서 ResponseDto 제작 예정
+     */
+    public Account findAccount(Long accountId) {
+        Account account = new Account().verifyAccount(accountRepository.findById(accountId));
+        return account;
+    }
+
+
+    /**
+     * 전체 회원 조회용 (Default는 10계정)
+     * @param pageable : page, size, sort 등 사용 가능
+     * @return Page 구조
+     */
+    public Page<Account> findAccounts (Pageable pageable) {
+        return accountRepository.findAll(pageable);
+    }
 
 }

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/value/Email.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/value/Email.java
@@ -1,0 +1,13 @@
+package tworeal.Animalcenter.domain.account.value;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class Email { private String email; }

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/value/Name.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/value/Name.java
@@ -1,0 +1,13 @@
+package tworeal.Animalcenter.domain.account.value;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class Name { private String name; }

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/value/Password.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/value/Password.java
@@ -1,0 +1,13 @@
+package tworeal.Animalcenter.domain.account.value;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+
+@Embeddable
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class Password { private String password; }

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/value/Phone.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/value/Phone.java
@@ -1,0 +1,15 @@
+package tworeal.Animalcenter.domain.account.value;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+
+@Getter
+@Embeddable
+@AllArgsConstructor
+@NoArgsConstructor
+public class Phone { private String phone;
+
+}

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/value/Photo.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/account/value/Photo.java
@@ -1,0 +1,13 @@
+package tworeal.Animalcenter.domain.account.value;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+
+@Getter  // Photo 클래스의 값을 조회하여 null 여부를 판정하기 위해 사용
+@Embeddable // Value로 지정
+@AllArgsConstructor
+@NoArgsConstructor
+public class Photo { private String photo; }

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/article/controller/ArticleController.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/article/controller/ArticleController.java
@@ -1,16 +1,19 @@
 package tworeal.Animalcenter.domain.article.controller;
 
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
-import tworeal.Animalcenter.global.dto.PageableInfoDto;
+import org.springframework.web.bind.annotation.*;
+import tworeal.Animalcenter.global.dto.PageInfoDto;
 import tworeal.Animalcenter.global.dto.SingleResDto;
 
-@RestController("/article")
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+@RequestMapping("/article")
 public class ArticleController {
 
     /**
@@ -54,10 +57,14 @@ public class ArticleController {
      *
      * @return 객체 ResponseDto를 Pageable로 감싸서 반환
      */
-    @GetMapping
-    public ResponseEntity<PageableInfoDto> getArticles() {
-
+    @GetMapping("/all")
+    public ResponseEntity<Page> getArticles(Pageable pageable) {
+        List<String> mockList = new ArrayList<>();
+        int count = 0;
+        while(count++<10) mockList.add("Mock"+count);
+        Page<String> page = new PageImpl(mockList, pageable, mockList.size());
+//        Page<String> dtoPage = page.map(String::new);
 //        Page<ArticleResDto> dtoPage = page.map(ArticleResDto::new);
-        return new ResponseEntity<>(new PageableInfoDto<>(), HttpStatus.OK);
+        return new ResponseEntity<>(page, HttpStatus.OK);
     }
 }

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/article/controller/ArticleController.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/article/controller/ArticleController.java
@@ -1,0 +1,63 @@
+package tworeal.Animalcenter.domain.article.controller;
+
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+import tworeal.Animalcenter.global.dto.PageableInfoDto;
+import tworeal.Animalcenter.global.dto.SingleResDto;
+
+@RestController("/article")
+public class ArticleController {
+
+    /**
+     * Mock Post
+     * @return 200
+     */
+    @PostMapping
+    public ResponseEntity<SingleResDto<String>> postArticle() {
+
+        return new ResponseEntity<>(new SingleResDto<>("Post Success"), HttpStatus.CREATED);
+    }
+
+
+    /**
+     * Mock Patch
+     * @return 200
+     */
+    @PatchMapping("/edit")
+    public ResponseEntity<SingleResDto<String>> patchArticle() {
+
+        return new ResponseEntity<>(new SingleResDto<>("Patch Success"), HttpStatus.OK);
+    }
+
+    /**
+     * Mock Delete (상태패턴 사용을 위해 실제로는 Patch로 할 것임
+     * @return 200 OK로 변경하기
+     */
+    @PatchMapping("/remove")
+    public ResponseEntity<SingleResDto<String>> deleteArticle() {
+        // 상태변환 필요
+        return new ResponseEntity<>(new SingleResDto<>("Delete Success"), HttpStatus.OK);
+    }
+
+    @GetMapping
+    public ResponseEntity<SingleResDto<String>> getArticle() {
+
+        return new ResponseEntity<>(new SingleResDto<>("Get Success"), HttpStatus.OK);
+    }
+
+    /**
+     *
+     * @return 객체 ResponseDto를 Pageable로 감싸서 반환
+     */
+    @GetMapping
+    public ResponseEntity<PageableInfoDto> getArticles() {
+
+//        Page<ArticleResDto> dtoPage = page.map(ArticleResDto::new);
+        return new ResponseEntity<>(new PageableInfoDto<>(), HttpStatus.OK);
+    }
+}

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/article/entity/Article.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/article/entity/Article.java
@@ -1,0 +1,18 @@
+package tworeal.Animalcenter.domain.article.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class Article {
+    @Id
+    private Long articleId;
+
+}

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/article/service/ArticleService.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/domain/article/service/ArticleService.java
@@ -1,0 +1,8 @@
+package tworeal.Animalcenter.domain.article.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class ArticleService {
+
+}

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/global/auditing/Auditable.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/global/auditing/Auditable.java
@@ -11,6 +11,9 @@ import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 
+/**
+ * abstract class를 사용할지 고민 후 결정 (현재는 BaseTimeEntity로 사용하기)
+ */
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
@@ -23,7 +26,10 @@ public abstract class Auditable {
     @Column(name = "LAST_MODIFIED_AT")
     private LocalDateTime modifiedAt;
 
-    @CreatedBy
-    @Column(updatable = false)
-    private String createdBy;
+    /**
+     * 생성한 사람은 필요시 추가
+     */
+//    @CreatedBy
+//    @Column(updatable = false)
+//    private String createdBy;
 }

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/global/dto/PageInfo.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/global/dto/PageInfo.java
@@ -1,12 +1,16 @@
 package tworeal.Animalcenter.global.dto;
 
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
-@AllArgsConstructor @Getter
+@AllArgsConstructor @Getter @Builder
 public class PageInfo {
     private int page;
     private int size;
     private long totalElements;
     private int totalPages;
 }
+/**
+ * DTO지만 setter를 지양하기 위해 @Builder 사용
+ */

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/global/dto/PageInfoDto.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/global/dto/PageInfoDto.java
@@ -10,13 +10,13 @@ import java.util.List;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class PageableInfoDto<T> {
+public class PageInfoDto<T> {
 
     private List<T> data;  // 감싸는 리스트 이름
 
     private PageInfo pageInfo;
 
-    public PageableInfoDto(Page<T> page) {
+    public PageInfoDto(Page<T> page) {
         data = page.getContent();  // 조회할 데이터
         PageInfo pageableInfo = PageInfo.builder()
                 .page(page.getPageable().getPageNumber())  // 페이지 번호 확인

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/global/dto/PageableInfoDto.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/global/dto/PageableInfoDto.java
@@ -14,18 +14,16 @@ public class PageableInfoDto<T> {
 
     private List<T> data;  // 감싸는 리스트 이름
 
-    private int size;
+    private PageInfo pageInfo;
 
-    private int totalPages;
-
-    private long totalElements;
-
-    private boolean first;  // 첫 페이지인지
-
-    private boolean last;   // 마지막 페이지인지
-
-    private boolean sorted; // 정렬 조건이 있는지
-
-    private int pageNumber;
-
+    public PageableInfoDto(Page<T> page) {
+        data = page.getContent();  // 조회할 데이터
+        PageInfo pageableInfo = PageInfo.builder()
+                .page(page.getPageable().getPageNumber())  // 페이지 번호 확인
+                .size(page.getSize())
+                .totalElements(page.getTotalElements())
+                .totalPages(page.getTotalPages())
+                .build();
+        pageInfo = pageableInfo;
+    }
 }

--- a/BE/Animalcenter/src/main/java/tworeal/Animalcenter/global/exception/exceptionCode/ExceptionCode.java
+++ b/BE/Animalcenter/src/main/java/tworeal/Animalcenter/global/exception/exceptionCode/ExceptionCode.java
@@ -6,6 +6,7 @@ public enum ExceptionCode {
     /**
      * 필요한 에러를 형식에 맞게 입력해주세요
      */
+    ACCOUNT_NOT_FOUND(400, "등록된 계정이 존재하지 않습니다."),
     NON_ACCESS_MODIFY(401, "수정권한이 없습니다.");
 
     @Getter


### PR DESCRIPTION
* Account 도메인 모델과 기본 CRUD API를 구현했습니다.
- Post : 계정을 생성합니다.
- Patch : 회원 정보를 수정할 수 있습니다. 일부의 값만 들어와도 부분 수정이 가능합니다. 회원 상태도 수정 가능합니다.
- Withdraw : 회원 탈퇴 상태변화를 위한 전용 API입니다.
- Delete : 회원 정보 삭재 API입니다. DB에서 계정정보가 삭제됩니다.
- Get : 단일 회원 조회용 API 입니다.
- Gets : 전체 회원 조회용 API입니다. 페이지네이션이 적용되며, 인자로는 pageable을 사용합니다.

* 기타 사항
- 로그인, 계정 정보 암호화, 비밀번호 암호화 등은 시큐리티 구현 후 수정될 예정입니다.
- 로그인 한 계정을 자동으로 추적하는 아이디 검증은 시큐리티 구현 후 수정될 예정입니다. 계정 검증을 위한 pathvariable은 추후 JWT로 대체되며 사라질 임시값입니다.